### PR TITLE
Add full name to Azure API Management and fix typo

### DIFF
--- a/docs/azure_jumpstart_arcbox/Full/_index.md
+++ b/docs/azure_jumpstart_arcbox/Full/_index.md
@@ -579,7 +579,7 @@ Please note it may take some time to show this status in the Azure portal, but s
 
 ### AdventureWorks API and Azure API Management
 
-This section guides you through deploying the AdventureWorks WebAPI workload on the _ArcBox-K3S_ cluster together with Azure APIM. This allows you to run workloads with intermittent internet connectivity and centralizes the control plane to align with other Azure Arc resource management. Example use cases include:
+This section guides you through deploying the AdventureWorks WebAPI workload on the _ArcBox-K3s_ cluster together with Azure APIM. This allows you to run workloads with intermittent internet connectivity and centralizes the control plane to align with other Azure Arc resource management. Example use cases include:
 
 - A farm in a rural area where data can be captured on-site to be synchronized to Azure for analysis with Azure Fabric.
 - A sport venue where ticket operation and data retention needs to remain onsite.

--- a/docs/azure_jumpstart_arcbox/Full/_index.md
+++ b/docs/azure_jumpstart_arcbox/Full/_index.md
@@ -579,7 +579,7 @@ Please note it may take some time to show this status in the Azure portal, but s
 
 ### AdventureWorks API and Azure API Management
 
-This section guides you through deploying the AdventureWorks WebAPI workload on the _ArcBox-K3s_ cluster together with [Azure API Management (APIM)](https://learn.microsoft.com/en-us/azure/api-management/api-management-key-concepts). This allows you to run workloads with intermittent internet connectivity and centralizes the control plane to align with other Azure Arc resource management. Example use cases include:
+This section guides you through deploying the AdventureWorks WebAPI workload on the _ArcBox-K3s_ cluster together with [Azure API Management (APIM)](https://learn.microsoft.com/azure/api-management/). This allows you to run workloads with intermittent internet connectivity and centralizes the control plane to align with other Azure Arc resource management. Example use cases include:
 
 - A farm in a rural area where data can be captured on-site to be synchronized to Azure for analysis with Azure Fabric.
 - A sport venue where ticket operation and data retention needs to remain onsite.

--- a/docs/azure_jumpstart_arcbox/Full/_index.md
+++ b/docs/azure_jumpstart_arcbox/Full/_index.md
@@ -579,7 +579,7 @@ Please note it may take some time to show this status in the Azure portal, but s
 
 ### AdventureWorks API and Azure API Management
 
-This section guides you through deploying the AdventureWorks WebAPI workload on the _ArcBox-K3s_ cluster together with Azure APIM. This allows you to run workloads with intermittent internet connectivity and centralizes the control plane to align with other Azure Arc resource management. Example use cases include:
+This section guides you through deploying the AdventureWorks WebAPI workload on the _ArcBox-K3s_ cluster together with [Azure API Management (APIM)](https://learn.microsoft.com/en-us/azure/api-management/api-management-key-concepts). This allows you to run workloads with intermittent internet connectivity and centralizes the control plane to align with other Azure Arc resource management. Example use cases include:
 
 - A farm in a rural area where data can be captured on-site to be synchronized to Azure for analysis with Azure Fabric.
 - A sport venue where ticket operation and data retention needs to remain onsite.


### PR DESCRIPTION
This pull request includes a single change to the documentation file `docs/azure_jumpstart_arcbox/Full/_index.md`. The change adds a link to the Azure API Management documentation for additional information and context.

* <a href="diffhunk://#diff-afa25513445734e6e1e0bc1335230bfaef50e390db0f6e0481ba72005e6873dbL582-R582">`docs/azure_jumpstart_arcbox/Full/_index.md`</a>: Added a link to the Azure API Management documentation for additional information and context.