### PR TITLE
Include note in the HCI AZD deployment to highlight different context between PowerShell and AZD CLI

### DIFF
--- a/docs/azure_jumpstart_hcibox/deployment_azd/_index.md
+++ b/docs/azure_jumpstart_hcibox/deployment_azd/_index.md
@@ -32,7 +32,8 @@ weight: 3
 ### Deploy the environment
 
 - Run the *`azd up`* command to deploy the environment. Azd will prompt you to enter the target subscription, region, and all required parameters. It is highly recommended to use _eastus_ as your region.
-
+  > **Note:** It is possible that you might experience error such as "Unable to acquire token". This is due to deployment script use PowerShell script. The credential in the PowerShell might be different to az CLI's crendential. then please run Connect-AzAccount in PowerShell with the correct credential and re-run azd up.Reference: [https://github.com/microsoft/azure_arc/issues/2443](https://github.com/microsoft/azure_arc/issues/2443)) 
+  
   ![Screenshot showing azd up](./azd_up.png)
 
 - Wait for the deployment to complete, then continue by logging into the _HCIBox-Client_ VM using RDP or Bastion.

--- a/docs/azure_jumpstart_hcibox/deployment_azd/_index.md
+++ b/docs/azure_jumpstart_hcibox/deployment_azd/_index.md
@@ -32,7 +32,7 @@ weight: 3
 ### Deploy the environment
 
 - Run the *`azd up`* command to deploy the environment. Azd will prompt you to enter the target subscription, region, and all required parameters. It is highly recommended to use _eastus_ as your region.
-  > **Note:** It is possible that you might experience error such as "Unable to acquire token". This is due to deployment script use PowerShell script. The credential in the PowerShell might be different to az CLI's crendential. then please run Connect-AzAccount in PowerShell with the correct credential and re-run azd up.Reference: [https://github.com/microsoft/azure_arc/issues/2443](https://github.com/microsoft/azure_arc/issues/2443)) 
+  > **Note:** It is possible that you might experience error such as "Unable to acquire token". This is due to deployment script use PowerShell script. The credential in the PowerShell might be different to az CLI's crendential. Please run Connect-AzAccount in PowerShell with the correct credential and re-run azd up. Reference: [https://github.com/microsoft/azure_arc/issues/2443](https://github.com/microsoft/azure_arc/issues/2443)). 
   
   ![Screenshot showing azd up](./azd_up.png)
 


### PR DESCRIPTION
This pull request includes a change in the `docs/azure_jumpstart_hcibox/deployment_azd/_index.md` file. The change adds a note to the deployment instructions providing guidance on how to resolve a potential error related to token acquisition. The error might occur due to differences between the credentials used by the PowerShell script and the az CLI. The note also includes a reference to a related issue on GitHub.

This is to address the issue #265 