### PR TITLE
hcibox region note

### DIFF
--- a/docs/azure_jumpstart_hcibox/deployment_az/_index.md
+++ b/docs/azure_jumpstart_hcibox/deployment_az/_index.md
@@ -13,6 +13,8 @@ Azure Bicep is used to deploy HCIBox into your Azure subscription. To deploy, yo
 
 ### Prepare the environment
 
+> **Note:** HCIBox can be deployed in the East US, Australia East, Canada Central and West Europe Azure regions. Deploying in other regions will result in unexpected behavior or failures. It requires 32 ESv5-series vCPUs when deploying with default parameters such as VM series/size. Ensure you have sufficient vCPU quota available in your Azure subscription and the region where you plan to deploy HCIBox. You can use the below Az CLI command to check your vCPU utilization.
+
 - Clone the Arc Jumpstart GitHub repository
 
   ```shell
@@ -28,8 +30,6 @@ Azure Bicep is used to deploy HCIBox into your Azure subscription. To deploy, yo
 - Login to AZ CLI using the *`az login`* command.
 
 - Ensure that you have selected the correct subscription you want to deploy HCIBox to by using the *`az account list --query "[?isDefault]"`* command. If you need to adjust the active subscription used by Az CLI, follow [this guidance](https://learn.microsoft.com/cli/azure/manage-azure-subscriptions-azure-cli#change-the-active-subscription).
-
-- **HCIBox requires 32 ESv5-series vCPUs** when deploying with default parameters such as VM series/size. Ensure you have sufficient vCPU quota available in your Azure subscription and the region where you plan to deploy HCIBox. You can use the below Az CLI command to check your vCPU utilization.
 
   ```shell
   az vm list-usage --location <your location> --output table
@@ -150,8 +150,6 @@ Example parameter-file:
   ```
 
   ![Screenshot showing bicep deploying](./bicep_deploying.png)
-
-    > **Note:** HCIBox can be deployed in East US, Australia East, Canada Central and West Europe. Deploying in other regions will result in unexpected behavior or failures.
 
 ## Start post-deployment automation
 


### PR DESCRIPTION
This pull request includes updates to the `docs/azure_jumpstart_hcibox/deployment_az/_index.md` file to improve the deployment instructions for HCIBox in Azure. The most important changes involve clarifying the deployment region requirements and updating the note about vCPU quotas.

Clarifications and updates to deployment instructions:

* Added a note specifying that HCIBox can be deployed in the East US, Australia East, Canada Central, and West Europe Azure regions, and that deploying in other regions may result in unexpected behavior or failures. This note also includes information about the required vCPU quota.
* Removed a redundant note about the 32 ESv5-series vCPUs requirement that was previously included in the deployment steps.
* Removed a duplicate note about the supported deployment regions from the example parameter-file section.