### PR TITLE
Update deployment pre-requisites to add "Microsoft.Compute" resource provider

### DIFF
--- a/docs/azure_jumpstart_ag/contoso_hypermarket/deployment/_index.md
+++ b/docs/azure_jumpstart_ag/contoso_hypermarket/deployment/_index.md
@@ -44,6 +44,7 @@ Once automation is complete, users can immediately start enjoying the Contoso Hy
 
   ```powershell
     $providers = @(
+        "Microsoft.Compute",
         "Microsoft.Kubernetes",
         "Microsoft.KubernetesConfiguration",
         "Microsoft.ExtendedLocation",
@@ -66,6 +67,7 @@ Once automation is complete, users can immediately start enjoying the Contoso Hy
 
 ```shell
     providers=(
+        "Microsoft.Compute",
         "Microsoft.Kubernetes"
         "Microsoft.KubernetesConfiguration"
         "Microsoft.ExtendedLocation"

--- a/docs/azure_jumpstart_arcbox/DataOps/_index.md
+++ b/docs/azure_jumpstart_arcbox/DataOps/_index.md
@@ -131,6 +131,7 @@ ArcBox uses an advanced automation flow to deploy and configure all necessary re
 - Register necessary Azure resource providers by running the following commands.
 
   ```shell
+  az provider register --namespace Microsoft.Compute --wait
   az provider register --namespace Microsoft.Kubernetes --wait
   az provider register --namespace Microsoft.KubernetesConfiguration --wait
   az provider register --namespace Microsoft.ExtendedLocation --wait

--- a/docs/azure_jumpstart_arcbox/DevOps/_index.md
+++ b/docs/azure_jumpstart_arcbox/DevOps/_index.md
@@ -153,6 +153,7 @@ ArcBox uses an advanced automation flow to deploy and configure all necessary re
 - Register necessary Azure resource providers by running the following commands.
 
   ```shell
+  az provider register --namespace Microsoft.Compute --wait
   az provider register --namespace Microsoft.Kubernetes --wait
   az provider register --namespace Microsoft.KubernetesConfiguration --wait
   az provider register --namespace Microsoft.PolicyInsights --wait

--- a/docs/azure_jumpstart_arcbox/ITPro/_index.md
+++ b/docs/azure_jumpstart_arcbox/ITPro/_index.md
@@ -104,6 +104,7 @@ ArcBox uses an advanced automation flow to deploy and configure all necessary re
 - Register necessary Azure resource providers by running the following commands.
 
   ```shell
+  az provider register --namespace Microsoft.Compute --wait
   az provider register --namespace Microsoft.HybridCompute --wait
   az provider register --namespace Microsoft.GuestConfiguration --wait
   az provider register --namespace Microsoft.AzureArcData --wait


### PR DESCRIPTION
This pull request includes updates to the documentation for various deployment guides within the Azure Jumpstart project. The main change is the addition of the `Microsoft.Compute` resource provider registration in multiple sections.

Updates to resource provider registration:

* [`docs/azure_jumpstart_ag/contoso_hypermarket/deployment/_index.md`](diffhunk://#diff-5d6a9ed1060004ad6b32268c5786c296b3c7dc0faa5d7c4dcaa2e8eb70cba792R47): Added `Microsoft.Compute` to the list of resource providers in both PowerShell and shell script examples. [[1]](diffhunk://#diff-5d6a9ed1060004ad6b32268c5786c296b3c7dc0faa5d7c4dcaa2e8eb70cba792R47) [[2]](diffhunk://#diff-5d6a9ed1060004ad6b32268c5786c296b3c7dc0faa5d7c4dcaa2e8eb70cba792R70)
* [`docs/azure_jumpstart_arcbox/DataOps/_index.md`](diffhunk://#diff-ee579ddc230a27f3395d98f99d7edb1e1e5e3badec914afe4a3cee160b270cd9R134): Added `az provider register --namespace Microsoft.Compute --wait` to the shell script for registering necessary Azure resource providers.
* [`docs/azure_jumpstart_arcbox/DevOps/_index.md`](diffhunk://#diff-4cc7344e71df48b47e30a5bfd52101c89edc500562c8ea1e31e00553a395105dR156): Added `az provider register --namespace Microsoft.Compute --wait` to the shell script for registering necessary Azure resource providers.
* [`docs/azure_jumpstart_arcbox/ITPro/_index.md`](diffhunk://#diff-7d493d06b8d1240eaba540869086dc9406cfa869d6fdfa6ade979cd5119d1419R107): Added `az provider register --namespace Microsoft.Compute --wait` to the shell script for registering necessary Azure resource providers.