### PR TITLE
ArcBox - move parameters into table

### DIFF
--- a/docs/azure_jumpstart_arcbox/DataOps/_index.md
+++ b/docs/azure_jumpstart_arcbox/DataOps/_index.md
@@ -200,17 +200,20 @@ $customLocationRPOID=(az ad sp list --filter "displayname eq 'Custom Locations R
   ```
 
 - Edit the [main.bicepparam](https://github.com/microsoft/azure_arc/blob/main/azure_jumpstart_arcbox/bicep/main.bicepparam) template parameters file and supply values for your environment.
-  - _`sshRSAPublicKey`_ - Your SSH public key
-  - _`tenantId`_ - Your Azure tenant id
-  - _`windowsAdminUsername`_ - Client Windows VM Administrator username
-  - _`logAnalyticsWorkspaceName`_ - Name for the ArcBox Log Analytics workspace that will be created
-  - _`flavor`_ - Use the value "DataOps" to specify that you want to deploy the DataOps flavor of ArcBox
-  - _`deployBastion`_ - Set to _`true`_ if you want to use Azure Bastion to connect to _ArcBox-Client_
-  - _`resourceTags`_ - Tags to assign for all ArcBox resources
-  - _`namingPrefix`_ - The naming prefix for the nested virtual machines and all Azure resources deployed. The maximum length for the naming prefix is 7 characters,example if the value is _Contoso_: `Contoso-Win2k19`
-  - _`sqlServerEdition`_ - SQL Server edition to deploy on the Hyper-V guest VM. Supported values are Developer, Standard, and Enterprise. Default is Developer edition. Azure Arc-enabled SQL Server features such as performance metrics requires Standard or Enterprise edition. Use this parameter to experience SQL Server performance metrics enabled by Azure Arc.
-  - _`windowsAdminPassword`_ - (optional) Client Windows VM Password. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long. If not specified, the default value is generated using the Bicep newGuid() function and stored in the Key Vault.
 
+  | Name                    | Type     | Description                                                                                                           | Default |
+  |-------------------------|----------|-----------------------------------------------------------------------------------------------------------------------|---------|
+  | _`sshRSAPublicKey`_     | string   | Your SSH Public Key                                                                                                   |         |
+  | _`tenantId`_            | string   | Your Azure tenant id                                                                                                  |         |
+  | _`windowsAdminUsername`_| string   | Client Windows VM Administrator username                                                                              |         |
+  | _`logAnalyticsWorkspaceName`_| string   | Name for the ArcBox Log Analytics workspace that will be created |  ArcBox-la  |
+  | _`flavor`_| string   | Use the value _`DataOps`_ to specify that you want to deploy the DataOps flavor of ArcBox |  ITPro  |
+  | _`deployBastion`_       | boolean  | Set to _`true`_ if you want to use Azure Bastion to connect to _ArcBox-Client_                        |  false   |
+  | _`resourceTags`_ | object   | Tags to assign for all ArcBox resources                                             |    Solution: 'jumpstart_arcbox'     |
+  | _`namingPrefix`_   | string   | The naming prefix for the nested virtual machines and all Azure resources deployed. The maximum length for the naming prefix is 7 characters,example if the value is _Contoso_: `Contoso-Win2k19`                                                                                          |  ArcBox    |
+  | _`sqlServerEdition`_ | string   | SQL Server edition to deploy on the Hyper-V guest VM. Supported values are Developer, Standard, and Enterprise. Azure Arc-enabled SQL Server features such as performance metrics requires Standard or Enterprise edition. Use this parameter to experience SQL Server performance metrics enabled by Azure Arc.                                                                                       | Developer |
+  | _`windowsAdminPassword`_      | string  | (optional) Client Windows VM Password. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long. If not specified, the default value is generated using the Bicep newGuid() function and stored in the Key Vault.                                                                     |    |
+  
   ![Screenshot showing example parameters](./parameters_dataops_bicep.png)
 
 - (optional) to use Spot VM instance for the _ArcBox-Client VM_, add a parameter called _`enableAzureSpotPricing`_ set to true.

--- a/docs/azure_jumpstart_arcbox/DevOps/_index.md
+++ b/docs/azure_jumpstart_arcbox/DevOps/_index.md
@@ -230,16 +230,19 @@ $customLocationRPOID=(az ad sp list --filter "displayname eq 'Custom Locations R
   ```
 
 - Edit the [main.bicepparam](https://github.com/microsoft/azure_arc/blob/main/azure_jumpstart_arcbox/bicep/main.bicepparam) template parameters file and supply values for your environment.
-  - _`sshRSAPublicKey`_ - Your SSH public key
-  - _`tenantId`_ - Your Azure tenant id
-  - _`windowsAdminUsername`_ - Client Windows VM Administrator username
-  - _`logAnalyticsWorkspaceName`_ - Name for the ArcBox Log Analytics workspace
-  - _`flavor`_ - Use the value _"DevOps"_ to specify that you want to deploy this specific flavor of ArcBox
-  - _`resourceTags`_ - Tags to assign for all ArcBox resources
-  - _`namingPrefix`_ - The naming prefix for the nested virtual machines and all Azure resources deployed. The maximum length for the naming prefix is 7 characters,example if the value is _Contoso_: `Contoso-Win2k19`
-  - _`deployBastion`_ - Set to _`true`_ if you want to use Azure Bastion to connect to _ArcBox-Client_
-  - _`githubUser`_ - Specify the name of your GitHub account where you cloned the Sample Apps repo
-  - _`windowsAdminPassword`_ - (optional) Client Windows VM Password. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long. If not specified, the default value is generated using the Bicep newGuid() function and stored in the Key Vault.
+
+  | Name                    | Type     | Description                                                                                                           | Default |
+  |-------------------------|----------|-----------------------------------------------------------------------------------------------------------------------|---------|
+  | _`sshRSAPublicKey`_     | string   | Your SSH Public Key                                                                                                   |         |
+  | _`tenantId`_            | string   | Your Azure tenant id                                                                                                  |         |
+  | _`windowsAdminUsername`_| string   | Client Windows VM Administrator username                                                                              |         |
+  | _`logAnalyticsWorkspaceName`_| string   | Name for the ArcBox Log Analytics workspace that will be created |  ArcBox-la  |
+  | _`flavor`_| string   | Use the value _`DevOps`_ to specify that you want to deploy the DevOps flavor of ArcBox |  ITPro  |
+  | _`deployBastion`_       | boolean  | Set to _`true`_ if you want to use Azure Bastion to connect to _ArcBox-Client_                        |  false   |
+  | _`resourceTags`_ | object   | Tags to assign for all ArcBox resources                                             |    Solution: 'jumpstart_arcbox'   |
+  | _`namingPrefix`_   | string   | The naming prefix for the nested virtual machines and all Azure resources deployed. The maximum length for the naming prefix is 7 characters,example if the value is _Contoso_: `Contoso-Win2k19`                                                                                          |  ArcBox    |
+  | _`githubUser`_ | string   | Specify the name of your GitHub account where you cloned the Sample Apps repo                                                                                       |   Azure   |
+  | _`windowsAdminPassword`_      | string  | (optional) Client Windows VM Password. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long. If not specified, the default value is generated using the Bicep newGuid() function and stored in the Key Vault.
 
   ![Screenshot showing example parameters](./parameters_devops_bicep.png)
 

--- a/docs/azure_jumpstart_arcbox/ITPro/_index.md
+++ b/docs/azure_jumpstart_arcbox/ITPro/_index.md
@@ -139,18 +139,21 @@ ArcBox uses an advanced automation flow to deploy and configure all necessary re
   ```
 
 - Edit the [main.bicepparam](https://github.com/microsoft/azure_arc/blob/main/azure_jumpstart_arcbox/bicep/main.bicepparam) template parameters file and supply values for your environment.
-  - _`tenantId`_ - Your Azure tenant id.
-  - _`windowsAdminUsername`_ - Client Windows VM Administrator username.
-  - _`logAnalyticsWorkspaceName`_ - Unique name for the ArcBox Log Analytics workspace.
-  - _`flavor`_ - Use the value _"ITPro"_ to specify that you want to deploy ArcBox for IT Pros.
-  - _`autoShutdownEnabled`_ - Optionally, you can set this to true if you want to configure the _ArcBox-Client_ VM to automatically shutdown to save costs.
-  - _`autoShutdownTime`_ - If _autoShutdownEnabled_ is set to true, this value specifies what time of the day to shut down the VM. If not specified, the default value is 18.00.
-  - _`autoShutdownTimezone`_ - If _autoShutdownEnabled_ is set to true, this value specifies what timezone will be used on conjunction with the value specified for _autoShutdownTime_ to shut down the VM. If not specified, the default value is _UTC_.
-  - _`autoShutdownEmailRecipient`_ - If _autoShutdownEnabled_ is set to true, this value specifies what e-mail address to notify 30 minutes prior to the scheduled shutdown.
-  - _`resourceTags`_ - Tags to assign for all ArcBox resources.
-  - _`namingPrefix`_ - The naming prefix for the nested virtual machines and all Azure resources.deployed. The maximum length for the naming prefix is 7 characters,example if the value is _Contoso_: `Contoso-Win2k25`.
-  - _`sqlServerEdition`_ - SQL Server edition to deploy on the Hyper-V guest VM. Supported values are Developer, Standard, and Enterprise. Default is Developer edition. Azure Arc-enabled SQL Server features such as performance metrics requires Standard or Enterprise edition. Use this parameter to experience SQL Server performance metrics enabled by Azure Arc.
-  - _`windowsAdminPassword`_ - (optional) Client Windows VM Password. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long. If not specified, the default value is generated using the Bicep newGuid() function and stored in the Key Vault.
+
+  | Name                    | Type     | Description                                                                                                           | Default |
+  |-------------------------|----------|-----------------------------------------------------------------------------------------------------------------------|---------|
+  | _`tenantId`_            | string   | Your Azure tenant id                                                                                                  |         |
+  | _`windowsAdminUsername`_| string   | Client Windows VM Administrator username                                                                              |         |
+  | _`logAnalyticsWorkspaceName`_| string   | Name for the ArcBox Log Analytics workspace that will be created |  ArcBox-la  |
+  | _`flavor`_| string   | Use the value _`ITPro`_ to specify that you want to deploy the ITPro flavor of ArcBox |  ITPro  |
+  | _`autoShutdownEnabled`_ | boolean   | Optionally, you can set this to true if you want to configure the _ArcBox-Client_ VM to automatically shutdown to save costs.                                             |   true    |
+  | _`autoShutdownTime`_ | string   | If _autoShutdownEnabled_ is set to true, this value specifies what time of the day to shut down the VM.                                             |   1800   |
+  | _`autoShutdownTimezone`_ | string   | If _autoShutdownEnabled_ is set to true, this value specifies what timezone will be used on conjunction with the value specified for _autoShutdownTime_ to shut down the VM.                                             |    UTC     |
+  | _`autoShutdownEmailRecipient`_ | string   | If _autoShutdownEnabled_ is set to true, this value specifies what e-mail address to notify 30 minutes prior to the scheduled shutdown.                                           |         |
+  | _`resourceTags`_ | object   | Tags to assign for all ArcBox resources                                             |    Solution: 'jumpstart_arcbox'     |
+  | _`namingPrefix`_   | string   | The naming prefix for the nested virtual machines and all Azure resources deployed. The maximum length for the naming prefix is 7 characters,example if the value is _Contoso_: `Contoso-Win2k19`                                                                                          |  ArcBox    |
+  | _`sqlServerEdition`_| string   | SQL Server edition to deploy on the Hyper-V guest VM. Supported values are Developer, Standard, and Enterprise. Azure Arc-enabled SQL Server features such as performance metrics requires Standard or Enterprise edition. Use this parameter to experience SQL Server performance metrics enabled by Azure Arc. |  Developer  |
+  | _`windowsAdminPassword`_      | string  | (optional) Client Windows VM Password. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long. If not specified, the default value is generated using the Bicep newGuid() function and stored in the Key Vault.
 
   ![Screenshot showing example parameters](./parameters_itpro_bicep.png)
 


### PR DESCRIPTION

This pull request updates the documentation for multiple Azure ArcBox flavors (`DataOps`, `DevOps`, and `ITPro`) by replacing parameter descriptions in plain text with a structured table format. This change improves readability and standardizes the presentation of deployment parameters.

### Documentation Updates:

* **DataOps Parameters**: Replaced the plain text list of deployment parameters with a table format in `docs/azure_jumpstart_arcbox/DataOps/_index.md`. The table includes details such as parameter names, types, descriptions, and default values.

* **DevOps Parameters**: Updated `docs/azure_jumpstart_arcbox/DevOps/_index.md` to use a table format for deployment parameters, improving clarity. Added a new parameter `_`githubUser`_` to specify the GitHub account name.

* **ITPro Parameters**: Converted the parameter list in `docs/azure_jumpstart_arcbox/ITPro/_index.md` to a table format. This includes additional parameters like `_`autoShutdownEnabled`_`, `_`autoShutdownTime`_`, `_`autoShutdownTimezone`_`, and `_`autoShutdownEmailRecipient`_` to support automatic VM shutdown configurations.

Closes #679 