### PR TITLE
Localbox 25q2 updates

### DIFF
--- a/docs/azure_jumpstart_arcbox/DataOps/_index.md
+++ b/docs/azure_jumpstart_arcbox/DataOps/_index.md
@@ -214,7 +214,8 @@ $customLocationRPOID=(az ad sp list --filter "displayname eq 'Custom Locations R
   | _`namingPrefix`_   | string   | The naming prefix for the nested virtual machines and all Azure resources deployed. The maximum length for the naming prefix is 7 characters,example if the value is _Contoso_: `Contoso-Win2k19`                                                                                          |  ArcBox    |
   | _`sqlServerEdition`_ | string   | SQL Server edition to deploy on the Hyper-V guest VM. Supported values are Developer, Standard, and Enterprise. Azure Arc-enabled SQL Server features such as performance metrics requires Standard or Enterprise edition. Use this parameter to experience SQL Server performance metrics enabled by Azure Arc.                                                                                       | Developer |
   | _`windowsAdminPassword`_ | string   | (optional) Client Windows VM Password. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long. If not specified, the default value is generated using the Bicep newGuid() function and stored in the Key Vault.                                                                                       |         |
-  
+  | `enableAzureSpotPricing` | string | Enable Azure VM Spot pricing for the ArcBox Client VM | false |
+
   ![Screenshot showing example parameters](./parameters_dataops_bicep.png)
 
 - (optional) to use Spot VM instance for the _ArcBox-Client VM_, add a parameter called _`enableAzureSpotPricing`_ set to true.

--- a/docs/azure_jumpstart_arcbox/DevOps/_index.md
+++ b/docs/azure_jumpstart_arcbox/DevOps/_index.md
@@ -244,6 +244,7 @@ $customLocationRPOID=(az ad sp list --filter "displayname eq 'Custom Locations R
   | _`namingPrefix`_   | string   | The naming prefix for the nested virtual machines and all Azure resources deployed. The maximum length for the naming prefix is 7 characters,example if the value is _Contoso_: `Contoso-Win2k19`                                                                                          |  ArcBox    |
   | _`githubUser`_ | string   | Specify the name of your GitHub account where you cloned the Sample Apps repo                                                                                       |   Azure   |
   | _`windowsAdminPassword`_ | string   | (optional) Client Windows VM Password. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long. If not specified, the default value is generated using the Bicep newGuid() function and stored in the Key Vault.                                                                                       |         |
+| `enableAzureSpotPricing` | string | Enable Azure VM Spot pricing for the ArcBox Client VM | false |
 
   ![Screenshot showing example parameters](./parameters_devops_bicep.png)
 

--- a/docs/azure_jumpstart_arcbox/ITPro/_index.md
+++ b/docs/azure_jumpstart_arcbox/ITPro/_index.md
@@ -155,6 +155,7 @@ ArcBox uses an advanced automation flow to deploy and configure all necessary re
   | _`namingPrefix`_   | string   | The naming prefix for the nested virtual machines and all Azure resources deployed. The maximum length for the naming prefix is 7 characters,example if the value is _Contoso_: `Contoso-Win2k19`                                                                                          |  ArcBox    |
   | _`sqlServerEdition`_| string   | SQL Server edition to deploy on the Hyper-V guest VM. Supported values are Developer, Standard, and Enterprise. Azure Arc-enabled SQL Server features such as performance metrics requires Standard or Enterprise edition. Use this parameter to experience SQL Server performance metrics enabled by Azure Arc. |  Developer  |
   | _`windowsAdminPassword`_ | string   | (optional) Client Windows VM Password. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long. If not specified, the default value is generated using the Bicep newGuid() function and stored in the Key Vault.                                                                                       |         |
+| `enableAzureSpotPricing` | string | Enable Azure VM Spot pricing for the ArcBox Client VM | false |
 
   ![Screenshot showing example parameters](./parameters_itpro_bicep.png)
 

--- a/docs/azure_jumpstart_localbox/deployment_az/_index.md
+++ b/docs/azure_jumpstart_localbox/deployment_az/_index.md
@@ -109,11 +109,11 @@ Azure Bicep is used to deploy LocalBox into your Azure subscription. Read on to 
 | `spnProviderId` | string | Entra ID object id for your _Microsoft.AzureStackHCI_ resource provider |  |
 | `tenantId` | string | Entra ID tenant id for your subscription |  |
 | `tags` | object | Tags to be added to all resources | {"Project": "jumpstart_LocalBox"} |
-| `vmAutologon` | bool | Enable automatic logon into LocalBox Virtual Machine | true |
+| `vmAutologon` | bool | Enable automatic logon into LocalBox Client VM | true |
 | `windowsAdminPassword` | securestring | Password for Windows account. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long |  |
 | `windowsAdminUsername` | string | Username for Windows account |  |
-| `vmSize` | string | The size of the Virtual Machine. Valid values: Standard_E32s_v5 and Standard_E32s_v6 | Standard_E32s_v6 |
-| `enableAzureSpotPricing` | string | The size of the Virtual Machine | false |
+| `vmSize` | string | The size of the LocalBox Client VM. Valid values: Standard_E32s_v5 and Standard_E32s_v6 | Standard_E32s_v6 |
+| `enableAzureSpotPricing` | string | Enable Azure VM Spot pricing for the LocalBox Client VM | false |
 
   > **Disclaimer:** The _governResourceTags_ parameter is optional and set to true by default. If not specified, both _CostControl: 'Ignore'_ and _SecurityControl: 'Ignore'_ tag values will be added. These tags are applicable to **ONLY Microsoft-internal Azure lab tenants** and designed for managing automated governance processes related to cost optimization and security controls. As mentioned, it will get added to the deployment **only** if the _governResourceTags_ parameter was set to true. If you are deploying LocalBox from a Microsoft-internal tenant and Azure subscription, this parameter is required to be set to 'true'. Failure to do so will cause your deployment to have issues and most likely to fail.
 

--- a/docs/azure_jumpstart_localbox/faq/_index.md
+++ b/docs/azure_jumpstart_localbox/faq/_index.md
@@ -30,13 +30,24 @@ LocalBox has been tested in the following Azure regions:
 - North Europe
 - West Europe
 
-Some LocalBox resources are deployed in specific regions where required services are available: australiaeast,southcentralus,eastus,westeurope,southeastasia,canadacentral,japaneast,centralindia. This can be controlled by specifying the `azureLocalInstanceLocation` deployment parameter.
+Some LocalBox resources are deployed in [specific regions](https://learn.microsoft.com/en-us/azure/azure-local/concepts/system-requirements-23h2?view=azloc-2505&tabs=azure-public#azure-requirements) where required services are available:
+
+- East US
+- West Europe
+- Australia East
+- Southeast Asia
+- India Central
+- Canada Central
+- Japan East
+- South Central US
+
+This can be controlled by specifying the `azureLocalInstanceLocation` deployment parameter.
 
 ## How much will it cost to use LocalBox?
 
 LocalBox incurs normal Azure consumption charges for various Azure resources such as virtual machines and storage.
 
-Consider using [Azure Spot VMs](https://learn.microsoft.com/azure/virtual-machines/spot-vms) to reduce compute costs, though this may result in eviction when Azure needs capacity.
+Consider using [Azure Spot VMs](https://learn.microsoft.com/azure/virtual-machines/spot-vms) to reduce compute costs, though this may result in eviction when Azure needs capacity. This can be enabled by specifying the value `true` for the `enableAzureSpotPricing` deployment parameter.
 
 You can view example estimates of LocalBox costs in the links below.
 


### PR DESCRIPTION
This pull request introduces updates to documentation for Azure Jumpstart projects, focusing on enabling Azure Spot Pricing and refining deployment parameters. The changes enhance clarity and functionality for users deploying Azure resources, particularly for ArcBox and LocalBox.

### Updates to deployment parameters:

* Added the `enableAzureSpotPricing` parameter to ArcBox documentation across multiple use cases (`DataOps`, `DevOps`, `ITPro`) to allow users to enable Azure VM Spot pricing for cost optimization. [[1]](diffhunk://#diff-ee579ddc230a27f3395d98f99d7edb1e1e5e3badec914afe4a3cee160b270cd9R217) [[2]](diffhunk://#diff-4cc7344e71df48b47e30a5bfd52101c89edc500562c8ea1e31e00553a395105dR247) [[3]](diffhunk://#diff-7d493d06b8d1240eaba540869086dc9406cfa869d6fdfa6ade979cd5119d1419R158)
* Updated LocalBox deployment parameters to clarify VM-related settings, including renaming `vmAutologon` and `vmSize` descriptions to specify "LocalBox Client VM". Also reintroduced the `enableAzureSpotPricing` parameter for LocalBox deployments.

### Refinements to documentation:

* Enhanced the FAQ section for LocalBox to include a detailed list of supported Azure regions and updated links to official Azure documentation for system requirements. Additionally, clarified how to enable Azure Spot Pricing using the `enableAzureSpotPricing` parameter.