### PR TITLE
Fixed typo in LocalBox documentation

### DIFF
--- a/docs/azure_jumpstart_localbox/deployment_az/_index.md
+++ b/docs/azure_jumpstart_localbox/deployment_az/_index.md
@@ -29,7 +29,7 @@ Azure Bicep is used to deploy LocalBox into your Azure subscription. Read on to 
   Register-AzResourceProvider -ProviderNamespace "Microsoft.HybridContainerService"
   Register-AzResourceProvider -ProviderNamespace "Microsoft.Attestation"
   Register-AzResourceProvider -ProviderNamespace "Microsoft.Storage"
-  Register-AzResourceProvider -ProviderNamespace "Microsoft Insights"
+  Register-AzResourceProvider -ProviderNamespace "Microsoft.Insights"
   ```
 
   Alternatively, you can register these providers using Azure CLI:


### PR DESCRIPTION
This pull request corrects a typo in the Azure resource provider namespace in the documentation to ensure proper registration of the `Microsoft.Insights` provider.

- Documentation fix:
  * Corrected the resource provider namespace from `Microsoft Insights` to `Microsoft.Insights` in the PowerShell registration instructions in `docs/azure_jumpstart_localbox/deployment_az/_index.md`.