### PR TITLE
Fix minor typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ⚡ Arc Jumpstart documentation
 
-Welcome to the Arc Jumpstart documentation repository! This repository is your go-to resource for in-depth guides, best practices, and detailed documentation related to Azure Arc. Whether you're a beginner exploring the basics or an experienced user optimizing your deployment, you'll find valuable insights tailored to your needs. This repository complements our [source code repository](https://aka.ms/JumpstartGitHubCode) and acts has the documentation source repository which populates the [Arc Jumpstart](https://aka.ms/arcjumpstart) website.
+Welcome to the Arc Jumpstart documentation repository! This repository is your go-to resource for in-depth guides, best practices, and detailed documentation related to Azure Arc. Whether you're a beginner exploring the basics or an experienced user optimizing your deployment, you'll find valuable insights tailored to your needs. This repository complements our [source code repository](https://aka.ms/JumpstartGitHubCode) and acts as the documentation source repository which populates the [Arc Jumpstart](https://aka.ms/arcjumpstart) website.
 
 <p align="center">
   <img src="/img/logo/jumpstart.png" alt="Arc Jumpstart logo" width="320">
@@ -18,7 +18,7 @@ Welcome to the Arc Jumpstart documentation repository! This repository is your g
 
 ## 🛠️ How to utilize this repository
 
-This documentation repository is tailored for contributors and works in tandem with the [our source code repository](https://aka.ms/JumpstartGitHubCode). While not mandatory, it's highly probable that contributors will need to clone both repositories to effectively contribute to Arc Jumpstart.
+This documentation repository is tailored for contributors and works in tandem with [our source code repository](https://aka.ms/JumpstartGitHubCode). While not mandatory, it's highly probable that contributors will need to clone both repositories to effectively contribute to Arc Jumpstart.
 
 Before you start, we recommend familiarizing yourself with our comprehensive [contribution guidelines](https://aka.ms/JumpstartContribution). These guidelines outline the standards and practices we follow, ensuring consistency and quality across our documentation.
 
@@ -34,7 +34,7 @@ The following branches are currently maintained:
 
 | Branch                                                       | Website                    | Description                                                                                      |
 | ------------------------------------------------------------ | -------------------------- | ------------------------------------------------------------------------------------------------ |
-| [main](https://github.com/Azure/arc_jumpstart_docs) (primary)               | https://jumpstart.azure.com/       | Latest Arc Jumpstart release documentation. This is the latest documentation available in the deployed to the production slot. |
+| [main](https://github.com/Azure/arc_jumpstart_docs) (primary)               | https://jumpstart.azure.com/       | Latest Arc Jumpstart release documentation. This is the latest documentation deployed to the production slot. |
 | [canary](https://github.com/Azure/arc_jumpstart_docs/tree/canary) (canary) | https://bvt.test.arcjumpstart.azure.com/ | Pre-release documentation. Doc updates should be merged to the canary branch for preview validation before merging to the main branch. |
 
 ## 📥 Cloning the repositories


### PR DESCRIPTION
This pull request makes minor improvements to the `README.md` documentation by fixing typos and clarifying some phrasing.

Documentation fixes and improvements:

* Corrected a typo from "acts has the documentation source repository" to "acts as the documentation source repository" in the introduction.
* Removed an unnecessary word ("the") to clarify the relationship with the source code repository in the contributor section.
* Improved the description of the `main` branch to clarify that it contains the latest documentation deployed to the production slot.